### PR TITLE
Check for already decoded UTF16 to ensure UTF-8 stays readable

### DIFF
--- a/UTF16.go
+++ b/UTF16.go
@@ -16,6 +16,17 @@ func UTF16() (u *UTF16Service) {
 }
 
 func (u *UTF16Service) DecodeAsBytes(utf16 []byte) (decoded []byte, err error) {
+	if len(utf16) < 2 {
+		return utf16, nil
+	}
+
+	if len(utf16) > 2 {
+		if utf16[1] != 0x00 {
+			// no decode needed.
+			return utf16, nil
+		}
+	}
+
 	decoded, _, err = transform.Bytes(unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM).NewDecoder(), utf16)
 	if err != nil {
 		return nil, TracedError(err)

--- a/UTF16_test.go
+++ b/UTF16_test.go
@@ -16,6 +16,11 @@ func TestUTF16DecodeAsString(t *testing.T) {
 		{[]byte{0x48, 0x00}, "H"},
 		{[]byte{0x48, 0x00, 0x65, 0x00}, "He"},
 		{[]byte{0x48, 0x00, 0x65, 0x00, 0x6c, 0x00, 0x6c, 0x00, 0x6f, 0x00}, "Hello"},
+
+		// Do not convert already UTF8 strings:
+		{[]byte("h"), "h"},
+		{[]byte("hello"), "hello"},
+		{[]byte(" hello"), " hello"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Check for already decoded UTF16 to ensure UTF-8 stays readable