### PR TITLE
Show repoPath in error message if unable to open local git repository

### DIFF
--- a/LocalGitRepository.go
+++ b/LocalGitRepository.go
@@ -157,7 +157,7 @@ func (l *LocalGitRepository) GetAsGoGitRepository() (goGitRepository *git.Reposi
 
 	goGitRepository, err = git.PlainOpen(repoPath)
 	if err != nil {
-		return nil, TracedErrorf("%w", err)
+		return nil, TracedErrorf("%w: repoPath='%s'", err, repoPath)
 	}
 
 	if goGitRepository == nil {


### PR DESCRIPTION
Show repoPath in error message if unable to open local git repository