### PR TITLE
Fix infity loop when requesting gitlab tags

### DIFF
--- a/GitlabTags.go
+++ b/GitlabTags.go
@@ -300,7 +300,7 @@ func (g *GitlabTags) ListTags(verbose bool) (gitlabTags []*GitlabTag, err error)
 
 		nativeList = append(nativeList, tags...)
 
-		if response.NextPage > 0 {
+		if response.NextPage <= 0 {
 			break
 		}
 


### PR DESCRIPTION
Fix infity loop when requesting gitlab tags