### PR TITLE
Rename http to httputils to gain clean separation

### DIFF
--- a/httputils/Client.go
+++ b/httputils/Client.go
@@ -1,4 +1,4 @@
-package http
+package httputils
 
 import "github.com/asciich/asciichgolangpublic/files"
 

--- a/httputils/Client_test.go
+++ b/httputils/Client_test.go
@@ -1,4 +1,4 @@
-package http
+package httputils
 
 import (
 	"strconv"
@@ -113,7 +113,6 @@ func TestClient_DownloadAsFile(t *testing.T) {
 		)
 	}
 }
-
 
 func TestClient_DownloadAsTempraryFile(t *testing.T) {
 	tests := []struct {

--- a/httputils/DownloadAsFileOptions.go
+++ b/httputils/DownloadAsFileOptions.go
@@ -1,4 +1,4 @@
-package http
+package httputils
 
 import (
 	"github.com/asciich/asciichgolangpublic/logging"

--- a/httputils/GenericResponse.go
+++ b/httputils/GenericResponse.go
@@ -1,4 +1,4 @@
-package http
+package httputils
 
 import (
 	"github.com/asciich/asciichgolangpublic/logging"

--- a/httputils/NativeClient.go
+++ b/httputils/NativeClient.go
@@ -1,4 +1,4 @@
-package http
+package httputils
 
 import (
 	"io"

--- a/httputils/RequestOptions.go
+++ b/httputils/RequestOptions.go
@@ -1,4 +1,4 @@
-package http
+package httputils
 
 import (
 	"strings"

--- a/httputils/Response.go
+++ b/httputils/Response.go
@@ -1,4 +1,4 @@
-package http
+package httputils
 
 type Response interface {
 	GetBodyAsString() (body string, err error)

--- a/httputils/Server.go
+++ b/httputils/Server.go
@@ -1,4 +1,4 @@
-package http
+package httputils
 
 import "errors"
 

--- a/httputils/StatusCodes.go
+++ b/httputils/StatusCodes.go
@@ -1,3 +1,3 @@
-package http
+package httputils
 
 const STATUS_CODE_OK = 200

--- a/httputils/TestWebServer.go
+++ b/httputils/TestWebServer.go
@@ -1,4 +1,4 @@
-package http
+package httputils
 
 import (
 	"context"


### PR DESCRIPTION
Rename http to httputils to gain clean separation