### PR TITLE
Use ctx instead of verbose in httputils. Added example for a GET request in httputils

### DIFF
--- a/pkg/httputils/Client.go
+++ b/pkg/httputils/Client.go
@@ -1,11 +1,15 @@
 package httputils
 
-import "github.com/asciich/asciichgolangpublic/files"
+import (
+	"context"
+
+	"github.com/asciich/asciichgolangpublic/files"
+)
 
 type Client interface {
-	DownloadAsFile(downloadOptions *DownloadAsFileOptions) (downloadedFile files.File, err error)
-	DownloadAsTemporaryFile(downloadOptions *DownloadAsFileOptions) (downloadedFile files.File, err error)
-	SendRequest(requestOptions *RequestOptions) (response Response, err error)
-	SendRequestAndGetBodyAsString(requestOptions *RequestOptions) (responseBody string, err error)
-	SendRequestAndRunYqQueryAgainstBody(requestOptions *RequestOptions, query string) (result string, err error)
+	DownloadAsFile(ctx context.Context, downloadOptions *DownloadAsFileOptions) (downloadedFile files.File, err error)
+	DownloadAsTemporaryFile(ctx context.Context, downloadOptions *DownloadAsFileOptions) (downloadedFile files.File, err error)
+	SendRequest(ctx context.Context, requestOptions *RequestOptions) (response Response, err error)
+	SendRequestAndGetBodyAsString(ctx context.Context, requestOptions *RequestOptions) (responseBody string, err error)
+	SendRequestAndRunYqQueryAgainstBody(ctx context.Context, requestOptions *RequestOptions, query string) (result string, err error)
 }

--- a/pkg/httputils/DownloadAsFileOptions.go
+++ b/pkg/httputils/DownloadAsFileOptions.go
@@ -8,7 +8,6 @@ type DownloadAsFileOptions struct {
 	RequestOptions    *RequestOptions
 	OutputPath        string
 	OverwriteExisting bool
-	Verbose           bool
 
 	// If Sha256Sum is set:
 	// - The download will be skipped if OutputPath has already the expected content.
@@ -52,11 +51,6 @@ func (d *DownloadAsFileOptions) GetRequestOptions() (requestOptions *RequestOpti
 	return d.RequestOptions, nil
 }
 
-func (d *DownloadAsFileOptions) GetVerbose() (verbose bool) {
-
-	return d.Verbose
-}
-
 func (d *DownloadAsFileOptions) SetOutputPath(outputPath string) (err error) {
 	if outputPath == "" {
 		return tracederrors.TracedErrorf("outputPath is empty string")
@@ -79,8 +73,4 @@ func (d *DownloadAsFileOptions) SetRequestOptions(requestOptions *RequestOptions
 	d.RequestOptions = requestOptions
 
 	return nil
-}
-
-func (d *DownloadAsFileOptions) SetVerbose(verbose bool) {
-	d.Verbose = verbose
 }

--- a/pkg/httputils/Example_PerformGetRequest_test.go
+++ b/pkg/httputils/Example_PerformGetRequest_test.go
@@ -1,0 +1,81 @@
+package httputils_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/asciich/asciichgolangpublic/pkg/httputils"
+)
+
+// Example how to perform a get request:
+// This is the generig SendRequest returning a full response we can handle on our own.
+// Hint: There are also more specify SendRequest... functions available returning directly specific values of the response as documented in the test cases below.
+func Test_Example_PerformGetRequest(t *testing.T) {
+	// Preparation start...
+	ctx := getCtx()
+
+	// This initalized the test web server
+	const port int = 9123
+
+	testServer, err := httputils.GetTestWebServer(port)
+	require.NoError(t, err)
+	defer testServer.Stop(ctx)
+
+	err = testServer.StartInBackground(ctx)
+	require.NoError(t, err)
+	// ... preparation end.
+
+	// To perform a GET request use:
+	response, err := httputils.SendRequest(
+		ctx,
+		&httputils.RequestOptions{
+			// Add the URL to request here:
+			Url: "http://localhost:9123/hello_world.txt",
+
+			// There is no need to specify the default method "GET":
+			// Method: "GET",
+		},
+	)
+	require.NoError(t, err)
+
+	// To access the response body/ payload as string use:
+	// Hint: There is the function SendR
+	body, err := response.GetBodyAsString()
+	require.NoError(t, err)
+
+	// No we can do with the received data whatever we want:
+	require.Contains(t, body, "hello world" )
+}
+
+// Example how to perform a get request and directly receive the received body/paiload as string:
+func Test_Example_PerformGetRequestAndGetBodyAsString(t *testing.T) {
+	// Preparation start...
+	ctx := getCtx()
+
+	// This initalized the test web server:
+	const port int = 9123
+
+	testServer, err := httputils.GetTestWebServer(port)
+	require.NoError(t, err)
+	defer testServer.Stop(ctx)
+
+	err = testServer.StartInBackground(ctx)
+	require.NoError(t, err)
+	// ... preparation end.
+
+	// To perform a GET request use:
+	response, err := httputils.SendRequestAndGetBodyAsString(
+		ctx,
+		&httputils.RequestOptions{
+			// Add the URL to request here:
+			Url: "http://localhost:9123/hello_world.txt",
+
+			// There is no need to specify the default method "GET":
+			// Method: "GET",
+		},
+	)
+	require.NoError(t, err)
+
+	// No we can do with the received data whatever we want:
+	require.Contains(t, response, "hello world" )
+}

--- a/pkg/httputils/HttpUtils.go
+++ b/pkg/httputils/HttpUtils.go
@@ -1,23 +1,23 @@
 package httputils
 
 import (
-	"github.com/asciich/asciichgolangpublic/logging"
+	"context"
+
 	"github.com/asciich/asciichgolangpublic/tracederrors"
 )
 
-func MustSendRequestAndGetBodyAsString(requestOptions *RequestOptions) (response string) {
-	response, err := SendRequestAndGetBodyAsString(requestOptions)
-	if err != nil {
-		logging.LogGoErrorFatal(err)
+func SendRequest(ctx context.Context, requestOptions *RequestOptions) (Response, error) {
+	if requestOptions == nil {
+		return nil, tracederrors.TracedErrorNil("requestOptions")
 	}
 
-	return response
+	return GetNativeClient().SendRequest(ctx, requestOptions)
 }
 
-func SendRequestAndGetBodyAsString(requestOptions *RequestOptions) (response string, err error) {
+func SendRequestAndGetBodyAsString(ctx context.Context, requestOptions *RequestOptions) (response string, err error) {
 	if requestOptions == nil {
 		return "", tracederrors.TracedErrorNil("requestOptions")
 	}
 
-	return GetNativeClient().SendRequestAndGetBodyAsString(requestOptions)
+	return GetNativeClient().SendRequestAndGetBodyAsString(ctx, requestOptions)
 }

--- a/pkg/httputils/README.md
+++ b/pkg/httputils/README.md
@@ -1,3 +1,7 @@
 # httputils
 
 High level easy to use HTTP client and testserver.
+
+## Examples
+
+* [GET request](Example_PerformGetRequest_test.go)

--- a/pkg/httputils/RequestOptions.go
+++ b/pkg/httputils/RequestOptions.go
@@ -19,9 +19,6 @@ type RequestOptions struct {
 
 	// Skip TLS validation
 	SkipTLSvalidation bool
-
-	// Enable verbose output
-	Verbose bool
 }
 
 func NewRequestOptions() (r *RequestOptions) {
@@ -73,11 +70,6 @@ func (r *RequestOptions) GetUrl() (url string, err error) {
 	return r.Url, nil
 }
 
-func (r *RequestOptions) GetVerbose() (verbose bool) {
-
-	return r.Verbose
-}
-
 func (r *RequestOptions) IsMethodSet() (isSet bool) {
 	return r.Method != ""
 }
@@ -114,8 +106,4 @@ func (r *RequestOptions) SetUrl(url string) (err error) {
 	r.Url = url
 
 	return nil
-}
-
-func (r *RequestOptions) SetVerbose(verbose bool) {
-	r.Verbose = verbose
 }

--- a/pkg/httputils/Server.go
+++ b/pkg/httputils/Server.go
@@ -1,11 +1,14 @@
 package httputils
 
-import "errors"
+import (
+	"context"
+	"errors"
+)
 
 var ErrWebServerAlreadyRunning = errors.New("web server already running")
 
 type Server interface {
 	GetPort() (port int, err error)
-	StartInBackground(verbose bool) (err error)
-	Stop(verbose bool) (err error)
+	StartInBackground(ctx context.Context) (err error)
+	Stop(ctx context.Context) (err error)
 }

--- a/pkg/httputils/TestWebServer.go
+++ b/pkg/httputils/TestWebServer.go
@@ -24,7 +24,7 @@ type TestWebServer struct {
 	tlsConfig          *tls.Config
 }
 
-func generateCertAndKeyForTestWebserver(ctx context.Context) (certAndKeyPair *x509utils.X509CertKeyPair, err error) {
+func GenerateCertAndKeyForTestWebserver(ctx context.Context) (certAndKeyPair *x509utils.X509CertKeyPair, err error) {
 	return x509utils.CreateSelfSignedCertificate(
 		ctx,
 		&x509utils.X509CreateCertificateOptions{
@@ -45,7 +45,7 @@ func GetTlsTestWebServer(ctx context.Context, port int) (webServer Server, err e
 		return nil, err
 	}
 
-	certAndKey, err := generateCertAndKeyForTestWebserver(ctx)
+	certAndKey, err := GenerateCertAndKeyForTestWebserver(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -159,18 +159,13 @@ func (t *TestWebServer) SetWebServerWaitGroup(webServerWaitGroup *sync.WaitGroup
 	return nil
 }
 
-func (t *TestWebServer) StartInBackground(verbose bool) (err error) {
+func (t *TestWebServer) StartInBackground(ctx context.Context) (err error) {
 	port, err := t.GetPort()
 	if err != nil {
 		return err
 	}
 
-	if verbose {
-		logging.LogInfof(
-			"Start testWebServer in background on port %d started.",
-			port,
-		)
-	}
+	logging.LogInfoByCtxf(ctx, "Start testWebServer in background on port %d started.", port)
 
 	if t.webServerWaitGroup == nil {
 		t.webServerWaitGroup = new(sync.WaitGroup)
@@ -212,12 +207,7 @@ func (t *TestWebServer) StartInBackground(verbose bool) (err error) {
 		}
 	}()
 
-	if verbose {
-		logging.LogInfof(
-			"Start testWebServer in background on port %d finished.",
-			port,
-		)
-	}
+	logging.LogInfoByCtxf(ctx, "Start testWebServer in background on port %d finished.", port)
 
 	return nil
 }
@@ -242,17 +232,11 @@ func (t *TestWebServer) SetTlsCertAndKey(ctx context.Context, certAndKey *x509ut
 	return nil
 }
 
-func (t *TestWebServer) Stop(verbose bool) (err error) {
-	if verbose {
-		logging.LogInfo(
-			"Stop TestWebServer started.",
-		)
-	}
+func (t *TestWebServer) Stop(ctx context.Context) (err error) {
+	logging.LogInfoByCtx(ctx, "Stop TestWebServer started.")
 
 	if t.webServerWaitGroup == nil {
-		if verbose {
-			logging.LogInfof("TestWebServer already stopped")
-		}
+		logging.LogInfoByCtxf(ctx, "TestWebServer already stopped")
 		return nil
 	}
 
@@ -271,11 +255,7 @@ func (t *TestWebServer) Stop(verbose bool) (err error) {
 	t.webServerWaitGroup.Wait()
 	t.webServerWaitGroup = nil
 
-	if verbose {
-		logging.LogInfo(
-			"Stop TestWebServer finished.",
-		)
-	}
+	logging.LogInfoByCtx(ctx, "Stop TestWebServer finished.")
 
 	return nil
 }

--- a/pkg/httputils/TestWebServer_test.go
+++ b/pkg/httputils/TestWebServer_test.go
@@ -1,4 +1,4 @@
-package httputils
+package httputils_test
 
 import (
 	"context"
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/asciich/asciichgolangpublic/pkg/contextutils"
+	"github.com/asciich/asciichgolangpublic/pkg/httputils"
 	"github.com/asciich/asciichgolangpublic/pkg/mustutils"
 )
 
@@ -17,11 +18,11 @@ func Test_TestWebServer_SetAndGetCertificate(t *testing.T) {
 	ctx := getCtx()
 	const port int = 9123
 
-	testServer := NewTestWebServer()
+	testServer := httputils.NewTestWebServer()
 	err := testServer.SetPort(port)
 	require.NoError(t, err)
 
-	certAndKey := mustutils.Must(generateCertAndKeyForTestWebserver(getCtx()))
+	certAndKey := mustutils.Must(httputils.GenerateCertAndKeyForTestWebserver(getCtx()))
 
 	mustutils.Must0(testServer.SetTlsCertAndKey(ctx, certAndKey))
 

--- a/prometheusutils/Prometheusutils.go
+++ b/prometheusutils/Prometheusutils.go
@@ -3,9 +3,8 @@ package prometheusutils
 import (
 	"context"
 
-	"github.com/asciich/asciichgolangpublic/pkg/httputils"
 	"github.com/asciich/asciichgolangpublic/logging"
-	"github.com/asciich/asciichgolangpublic/pkg/contextutils"
+	"github.com/asciich/asciichgolangpublic/pkg/httputils"
 	"github.com/asciich/asciichgolangpublic/tracederrors"
 )
 
@@ -52,10 +51,10 @@ func GetParsedMetricPage(ctx context.Context, url string) (metrics *PrometheusPa
 	}
 
 	m, err := httputils.SendRequestAndGetBodyAsString(
+		ctx,
 		&httputils.RequestOptions{
-			Url:     url,
-			Method:  "GET",
-			Verbose: contextutils.GetVerboseFromContext(ctx),
+			Url:    url,
+			Method: "GET",
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
Use ctx instead of verbose in httputils. Added example for a GET request in httputils