### PR TITLE
Use ctx instead of verbose in fileinterface functions IsLocalFile, CheckIsLocalFile and Chown

### DIFF
--- a/pkg/artifacthandler/ArtifactHandler.go
+++ b/pkg/artifacthandler/ArtifactHandler.go
@@ -10,7 +10,7 @@ import (
 // While artifacts could be some compiled binaries, docker images, vm images...
 type ArtifactHandler interface {
 	DownloadAndValidateArtifact(ctx context.Context, downloadOptions *artifactparameteroptions.ArtifactDownloadOptions) (string, error)
-	GetLatestArtifactVersionAsString(artifactName string, verbose bool) (string, error)
+	GetLatestArtifactVersionAsString(ctx context.Context, artifactName string) (string, error)
 	IsHandlingArtifactByName(artifactName string) (bool, error)
 	UploadBinaryArtifact(ctx context.Context, uploadOptions *artifactparameteroptions.UploadArtifactOptions) error
 }

--- a/pkg/files/CommandExecutorFile.go
+++ b/pkg/files/CommandExecutorFile.go
@@ -108,7 +108,7 @@ func (c *CommandExecutorFile) Chmod(ctx context.Context, chmodOptions *filesopti
 	return nil
 }
 
-func (c *CommandExecutorFile) Chown(options *parameteroptions.ChownOptions) (err error) {
+func (c *CommandExecutorFile) Chown(ctx context.Context, options *parameteroptions.ChownOptions) (err error) {
 	if options == nil {
 		return tracederrors.TracedErrorNil("options")
 	}
@@ -153,14 +153,7 @@ func (c *CommandExecutorFile) Chown(options *parameteroptions.ChownOptions) (err
 		return err
 	}
 
-	if options.Verbose {
-		logging.LogChangedf(
-			"Changed ownership of file '%s' to '%s' on host '%s'",
-			path,
-			userAndGroupForCommand,
-			hostDescription,
-		)
-	}
+	logging.LogChangedByCtxf(ctx, "Changed ownership of file '%s' to '%s' on host '%s'", path, userAndGroupForCommand, hostDescription)
 
 	return nil
 }
@@ -658,13 +651,6 @@ func (c *CommandExecutorFile) MustAppendBytes(toWrite []byte, verbose bool) {
 
 func (c *CommandExecutorFile) MustAppendString(toWrite string, verbose bool) {
 	err := c.AppendString(toWrite, verbose)
-	if err != nil {
-		logging.LogGoErrorFatal(err)
-	}
-}
-
-func (c *CommandExecutorFile) MustChown(options *parameteroptions.ChownOptions) {
-	err := c.Chown(options)
 	if err != nil {
 		logging.LogGoErrorFatal(err)
 	}

--- a/pkg/files/CommandExecutorFile_test.go
+++ b/pkg/files/CommandExecutorFile_test.go
@@ -28,7 +28,10 @@ func TestCommandExecutorFileReadAndWrite(t *testing.T) {
 
 				temporaryFilePath := createTempFileAndGetPath()
 
-				var fileToTest filesinterfaces.File = files.MustGetLocalCommandExecutorFileByPath(temporaryFilePath)
+				var fileToTest filesinterfaces.File
+				var err error
+				fileToTest, err = files.GetLocalCommandExecutorFileByPath(temporaryFilePath)
+				require.NoError(t, err)
 				defer fileToTest.Delete(ctx, &filesoptions.DeleteOptions{})
 
 				exists, err := fileToTest.Exists(ctx)

--- a/pkg/files/FileBase.go
+++ b/pkg/files/FileBase.go
@@ -41,7 +41,7 @@ func NewFileBase() (f *FileBase) {
 // Returns true if the file is a file on the local host.
 //
 // If a file can return a local path the assumption is it is a local file.
-func (f *FileBase) IsLocalFile(verbose bool) (isLocalFile bool, err error) {
+func (f *FileBase) IsLocalFile(ctx context.Context) (isLocalFile bool, err error) {
 	parent, err := f.GetParentFileForBaseClass()
 	if err != nil {
 		return false, err
@@ -55,12 +55,7 @@ func (f *FileBase) IsLocalFile(verbose bool) (isLocalFile bool, err error) {
 		)
 	}
 
-	if verbose {
-		logging.LogInfof(
-			"'%s' is a local file.",
-			localPath,
-		)
-	}
+	logging.LogInfoByCtxf(ctx, "'%s' is a local file.", localPath)
 
 	return true, nil
 }
@@ -94,13 +89,13 @@ func (f *FileBase) AppendLine(line string, verbose bool) (err error) {
 	return nil
 }
 
-func (f *FileBase) CheckIsLocalFile(verbose bool) (err error) {
+func (f *FileBase) CheckIsLocalFile(ctx context.Context) (err error) {
 	parent, err := f.GetParentFileForBaseClass()
 	if err != nil {
 		return err
 	}
 
-	isLocalFile, err := parent.IsLocalFile(verbose)
+	isLocalFile, err := parent.IsLocalFile(ctx)
 	if err != nil {
 		return err
 	}
@@ -656,12 +651,6 @@ func (f *FileBase) MustAppendLine(line string, verbose bool) {
 	}
 }
 
-func (f *FileBase) MustCheckIsLocalFile(verbose bool) {
-	err := f.CheckIsLocalFile(verbose)
-	if err != nil {
-		logging.LogGoErrorFatal(err)
-	}
-}
 
 func (f *FileBase) MustContainsLine(line string) (containsLine bool) {
 	containsLine, err := f.ContainsLine(line)
@@ -817,15 +806,6 @@ func (f *FileBase) MustIsEmptyFile() (isEmtpyFile bool) {
 	}
 
 	return isEmtpyFile
-}
-
-func (f *FileBase) MustIsLocalFile(verbose bool) (isLocalFile bool) {
-	isLocalFile, err := f.IsLocalFile(verbose)
-	if err != nil {
-		logging.LogGoErrorFatal(err)
-	}
-
-	return isLocalFile
 }
 
 func (f *FileBase) MustIsMatchingSha256Sum(sha256sum string) (isMatching bool) {

--- a/pkg/files/File_test.go
+++ b/pkg/files/File_test.go
@@ -34,7 +34,7 @@ func getFileToTest(implementationName string) (file filesinterfaces.File) {
 	}
 
 	if implementationName == "localCommandExecutorFile" {
-		return files.MustGetLocalCommandExecutorFileByPath(createTempFileAndGetPath())
+		return mustutils.Must(files.GetLocalCommandExecutorFileByPath(createTempFileAndGetPath()))
 	}
 
 	logging.LogFatalWithTracef("unknown implementationName='%s'", implementationName)

--- a/pkg/files/LocalCommandExecutorFile.go
+++ b/pkg/files/LocalCommandExecutorFile.go
@@ -1,10 +1,11 @@
 package files
 
 import (
+	"context"
+
 	"github.com/asciich/asciichgolangpublic/pkg/commandexecutor/commandexecutorbashoo"
 	"github.com/asciich/asciichgolangpublic/pkg/commandexecutor/commandexecutorinterfaces"
 	"github.com/asciich/asciichgolangpublic/pkg/filesutils/filesinterfaces"
-	"github.com/asciich/asciichgolangpublic/pkg/logging"
 	"github.com/asciich/asciichgolangpublic/pkg/tracederrors"
 )
 
@@ -32,12 +33,12 @@ func GetCommandExecutorFileByPath(commandExector commandexecutorinterfaces.Comma
 	return commandExecutorFile, nil
 }
 
-func GetLocalCommandExecutorFileByFile(file filesinterfaces.File, verbose bool) (commandExecutorFile *CommandExecutorFile, err error) {
+func GetLocalCommandExecutorFileByFile(ctx context.Context, file filesinterfaces.File) (commandExecutorFile *CommandExecutorFile, err error) {
 	if file == nil {
 		return nil, tracederrors.TracedErrorEmptyString("file")
 	}
 
-	err = file.CheckIsLocalFile(verbose)
+	err = file.CheckIsLocalFile(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -61,31 +62,4 @@ func GetLocalCommandExecutorFileByPath(localPath string) (commandExecutorFile *C
 	}
 
 	return GetCommandExecutorFileByPath(commandexecutorbashoo.Bash(), localPath)
-}
-
-func MustGetCommandExecutorFileByPath(commandExector commandexecutorinterfaces.CommandExecutor, path string) (commandExecutorFile *CommandExecutorFile) {
-	commandExecutorFile, err := GetCommandExecutorFileByPath(commandExector, path)
-	if err != nil {
-		logging.LogGoErrorFatal(err)
-	}
-
-	return commandExecutorFile
-}
-
-func MustGetLocalCommandExecutorFileByFile(file filesinterfaces.File, verbose bool) (commandExecutorFile *CommandExecutorFile) {
-	commandExecutorFile, err := GetLocalCommandExecutorFileByFile(file, verbose)
-	if err != nil {
-		logging.LogGoErrorFatal(err)
-	}
-
-	return commandExecutorFile
-}
-
-func MustGetLocalCommandExecutorFileByPath(localPath string) (commandExecutorFile *CommandExecutorFile) {
-	commandExecutorFile, err := GetLocalCommandExecutorFileByPath(localPath)
-	if err != nil {
-		logging.LogGoErrorFatal(err)
-	}
-
-	return commandExecutorFile
 }

--- a/pkg/files/LocalFile.go
+++ b/pkg/files/LocalFile.go
@@ -157,7 +157,7 @@ func (l *LocalFile) Chmod(ctx context.Context, chmodOptions *filesoptions.ChmodO
 	return nativefiles.Chmod(ctx, path, chmodOptions)
 }
 
-func (l *LocalFile) Chown(options *parameteroptions.ChownOptions) (err error) {
+func (l *LocalFile) Chown(ctx context.Context, options *parameteroptions.ChownOptions) (err error) {
 	if options == nil {
 		return tracederrors.TracedErrorNil("options")
 	}
@@ -197,14 +197,7 @@ func (l *LocalFile) Chown(options *parameteroptions.ChownOptions) (err error) {
 		return err
 	}
 
-	if options.Verbose {
-		logging.LogChangedf(
-			"Changed ownership of file '%s' to '%s' on host '%s'",
-			path,
-			userAndGroupForCommand,
-			hostDescription,
-		)
-	}
+	logging.LogChangedByCtxf(ctx, "Changed ownership of file '%s' to '%s' on host '%s'", path, userAndGroupForCommand, hostDescription)
 
 	return nil
 }

--- a/pkg/filesutils/TemporaryFiles_test.go
+++ b/pkg/filesutils/TemporaryFiles_test.go
@@ -37,7 +37,7 @@ func getFileToTest(implementationName string, path string) (fileToTest filesinte
 	}
 
 	if implementationName == "localCommandExecutorFile" {
-		return files.MustGetLocalCommandExecutorFileByPath(path)
+		return mustutils.Must(files.GetLocalCommandExecutorFileByPath(path))
 	}
 
 	logging.LogFatalWithTracef("Unknown implementation name '%s'", implementationName)

--- a/pkg/filesutils/filesinterfaces/File.go
+++ b/pkg/filesutils/filesinterfaces/File.go
@@ -14,7 +14,7 @@ type File interface {
 	AppendBytes(toWrite []byte, verbose bool) (err error)
 	AppendString(toWrite string, verbose bool) (err error)
 	Chmod(ctx context.Context, options *filesoptions.ChmodOptions) (err error)
-	Chown(options *parameteroptions.ChownOptions) (err error)
+	Chown(ctx context.Context, options *parameteroptions.ChownOptions) (err error)
 	CopyToFile(destFile File, verbose bool) (err error)
 	Create(ctx context.Context, options *filesoptions.CreateOptions) (err error)
 	Delete(ctx context.Context, options *filesoptions.DeleteOptions) (err error)
@@ -39,7 +39,7 @@ type File interface {
 
 	// All methods below this line can be implemented by embedding the `FileBase` struct:
 	AppendLine(line string, verbose bool) (err error)
-	CheckIsLocalFile(verbose bool) (err error)
+	CheckIsLocalFile(ctx context.Context) (err error)
 	ContainsLine(line string) (containsLine bool, err error)
 	CreateParentDirectory(verbose bool) (err error)
 	EnsureLineInFile(line string, verbose bool) (err error)
@@ -57,7 +57,7 @@ type File interface {
 	GetValueAsString(key string) (value string, err error)
 	IsContentEqualByComparingSha256Sum(other File, verbose bool) (isMatching bool, err error)
 	IsEmptyFile() (isEmpty bool, err error)
-	IsLocalFile(verbose bool) (isLocalFile bool, err error)
+	IsLocalFile(ctx context.Context) (isLocalFile bool, err error)
 	IsMatchingSha256Sum(sha256sum string) (isMatching bool, err error)
 	IsPgpEncrypted(verbose bool) (isPgpEncrypted bool, err error)
 	IsYYYYmmdd_HHMMSSPrefix() (hasDatePrefix bool, err error)

--- a/pkg/filesutils/tempfilesoo/TemporaryFiles.go
+++ b/pkg/filesutils/tempfilesoo/TemporaryFiles.go
@@ -131,7 +131,7 @@ func CreateTemporaryFileFromFile(ctx context.Context, fileToCopyAsTemporaryFile 
 		return nil, err
 	}
 
-	isLocalFile, err := fileToCopyAsTemporaryFile.IsLocalFile(contextutils.GetVerboseFromContext(ctx))
+	isLocalFile, err := fileToCopyAsTemporaryFile.IsLocalFile(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/hosts/Host.go
+++ b/pkg/hosts/Host.go
@@ -22,7 +22,7 @@ type Host interface {
 	GetHostDescription() (hostDescription string, err error)
 	GetHostName() (hostName string, err error)
 	GetSshPublicKeyOfUserAsString(ctx context.Context, username string) (publicKey string, err error)
-	InstallBinary(installOptions *parameteroptions.InstallOptions) (installedFile filesinterfaces.File, err error)
+	InstallBinary(ctx context.Context, installOptions *parameteroptions.InstallOptions) (installedFile filesinterfaces.File, err error)
 	RunCommand(ctx context.Context, runCommandOptions *parameteroptions.RunCommandOptions) (commandOutput *commandoutput.CommandOutput, err error)
 
 	// All methods below this line can be implemented by embedding the `CommandExecutorBase` struct:

--- a/pkg/parameteroptions/ChownOptions.go
+++ b/pkg/parameteroptions/ChownOptions.go
@@ -8,7 +8,6 @@ type ChownOptions struct {
 	UserName  string
 	GroupName string
 	UseSudo   bool
-	Verbose   bool
 }
 
 func NewChownOptions() (c *ChownOptions) {
@@ -54,11 +53,6 @@ func (c *ChownOptions) GetUserName() (userName string, err error) {
 	return c.UserName, nil
 }
 
-func (c *ChownOptions) GetVerbose() (verbose bool) {
-
-	return c.Verbose
-}
-
 func (c *ChownOptions) IsGroupNameSet() (isSet bool) {
 	return c.GroupName != ""
 }
@@ -85,8 +79,4 @@ func (c *ChownOptions) SetUserName(userName string) (err error) {
 	c.UserName = userName
 
 	return nil
-}
-
-func (c *ChownOptions) SetVerbose(verbose bool) {
-	c.Verbose = verbose
 }

--- a/pkg/parameteroptions/InstallOptions.go
+++ b/pkg/parameteroptions/InstallOptions.go
@@ -12,7 +12,6 @@ type InstallOptions struct {
 	InstallationPath      string
 	InstallBashCompletion bool
 	UseSudoToInstall      bool
-	Verbose               bool
 }
 
 func NewInstallOptions() (i *InstallOptions) {
@@ -68,11 +67,6 @@ func (i *InstallOptions) GetUseSudoToInstall() (useSudoToInstall bool) {
 	return i.UseSudoToInstall
 }
 
-func (i *InstallOptions) GetVerbose() (verbose bool) {
-
-	return i.Verbose
-}
-
 func (i *InstallOptions) SetBinaryName(binaryName string) (err error) {
 	if binaryName == "" {
 		return tracederrors.TracedErrorf("binaryName is empty string")
@@ -109,8 +103,4 @@ func (i *InstallOptions) SetSourcePath(sourcePath string) (err error) {
 
 func (i *InstallOptions) SetUseSudoToInstall(useSudoToInstall bool) {
 	i.UseSudoToInstall = useSudoToInstall
-}
-
-func (i *InstallOptions) SetVerbose(verbose bool) {
-	i.Verbose = verbose
 }

--- a/pkg/parameteroptions/UpdateDependenciesOptions.go
+++ b/pkg/parameteroptions/UpdateDependenciesOptions.go
@@ -1,6 +1,8 @@
 package parameteroptions
 
 import (
+	"context"
+
 	"github.com/asciich/asciichgolangpublic/pkg/artifacthandler"
 	"github.com/asciich/asciichgolangpublic/pkg/parameteroptions/authenticationoptions"
 	"github.com/asciich/asciichgolangpublic/pkg/tracederrors"
@@ -70,7 +72,7 @@ func (u *UpdateDependenciesOptions) GetCommit() (commit bool, err error) {
 	return u.Commit, nil
 }
 
-func (u *UpdateDependenciesOptions) GetLatestArtifactVersionAsString(softwareName string, verbose bool) (latestVersion string, err error) {
+func (u *UpdateDependenciesOptions) GetLatestArtifactVersionAsString(ctx context.Context, softwareName string) (latestVersion string, err error) {
 	if softwareName == "" {
 		return "", tracederrors.TracedError("softwareName is empty string")
 	}
@@ -80,7 +82,7 @@ func (u *UpdateDependenciesOptions) GetLatestArtifactVersionAsString(softwareNam
 		return "", err
 	}
 
-	latestVersion, err = artifactHandler.GetLatestArtifactVersionAsString(softwareName, verbose)
+	latestVersion, err = artifactHandler.GetLatestArtifactVersionAsString(ctx, softwareName)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/parameteroptions/artifactparameteroptions/ArtifactDownloadOptions.go
+++ b/pkg/parameteroptions/artifactparameteroptions/ArtifactDownloadOptions.go
@@ -9,7 +9,6 @@ type ArtifactDownloadOptions struct {
 	OutputPath        string
 	VersionToDownload string
 	OverwriteExisting bool
-	Verbose           bool
 }
 
 func NewArtifactDownloadOptions() (a *ArtifactDownloadOptions) {
@@ -39,11 +38,6 @@ func (a *ArtifactDownloadOptions) GetOutputPath() (outputPath string, err error)
 func (a *ArtifactDownloadOptions) GetOverwriteExisting() (overwriteExisting bool, err error) {
 
 	return a.OverwriteExisting, nil
-}
-
-func (a *ArtifactDownloadOptions) GetVerbose() (verbose bool, err error) {
-
-	return a.Verbose, nil
 }
 
 func (a *ArtifactDownloadOptions) GetVersionToDownload() (versionToDownload string, err error) {
@@ -84,12 +78,6 @@ func (a *ArtifactDownloadOptions) SetOutputPath(outputPath string) (err error) {
 
 func (a *ArtifactDownloadOptions) SetOverwriteExisting(overwriteExisting bool) (err error) {
 	a.OverwriteExisting = overwriteExisting
-
-	return nil
-}
-
-func (a *ArtifactDownloadOptions) SetVerbose(verbose bool) (err error) {
-	a.Verbose = verbose
 
 	return nil
 }

--- a/pkg/pgp/gnupg/GnuPGSignOptions.go
+++ b/pkg/pgp/gnupg/GnuPGSignOptions.go
@@ -3,7 +3,6 @@ package gnupg
 import "github.com/asciich/asciichgolangpublic/pkg/logging"
 
 type GnuPGSignOptions struct {
-	Verbose      bool
 	DetachedSign bool
 	AsciiArmor   bool
 }
@@ -22,11 +21,6 @@ func (g *GnuPGSignOptions) GetDetachedSign() (detachedSign bool, err error) {
 	return g.DetachedSign, nil
 }
 
-func (g *GnuPGSignOptions) GetVerbose() (verbose bool, err error) {
-
-	return g.Verbose, nil
-}
-
 func (g *GnuPGSignOptions) MustGetAsciiArmor() (asciiArmor bool) {
 	asciiArmor, err := g.GetAsciiArmor()
 	if err != nil {
@@ -34,45 +28,6 @@ func (g *GnuPGSignOptions) MustGetAsciiArmor() (asciiArmor bool) {
 	}
 
 	return asciiArmor
-}
-
-func (g *GnuPGSignOptions) MustGetDetachedSign() (detachedSign bool) {
-	detachedSign, err := g.GetDetachedSign()
-	if err != nil {
-		logging.LogGoErrorFatal(err)
-	}
-
-	return detachedSign
-}
-
-func (g *GnuPGSignOptions) MustGetVerbose() (verbose bool) {
-	verbose, err := g.GetVerbose()
-	if err != nil {
-		logging.LogGoErrorFatal(err)
-	}
-
-	return verbose
-}
-
-func (g *GnuPGSignOptions) MustSetAsciiArmor(asciiArmor bool) {
-	err := g.SetAsciiArmor(asciiArmor)
-	if err != nil {
-		logging.LogGoErrorFatal(err)
-	}
-}
-
-func (g *GnuPGSignOptions) MustSetDetachedSign(detachedSign bool) {
-	err := g.SetDetachedSign(detachedSign)
-	if err != nil {
-		logging.LogGoErrorFatal(err)
-	}
-}
-
-func (g *GnuPGSignOptions) MustSetVerbose(verbose bool) {
-	err := g.SetVerbose(verbose)
-	if err != nil {
-		logging.LogGoErrorFatal(err)
-	}
 }
 
 func (g *GnuPGSignOptions) SetAsciiArmor(asciiArmor bool) (err error) {
@@ -83,12 +38,6 @@ func (g *GnuPGSignOptions) SetAsciiArmor(asciiArmor bool) (err error) {
 
 func (g *GnuPGSignOptions) SetDetachedSign(detachedSign bool) (err error) {
 	g.DetachedSign = detachedSign
-
-	return nil
-}
-
-func (g *GnuPGSignOptions) SetVerbose(verbose bool) (err error) {
-	g.Verbose = verbose
 
 	return nil
 }

--- a/pkg/pgp/gnupg/GnuPG_test.go
+++ b/pkg/pgp/gnupg/GnuPG_test.go
@@ -35,9 +35,9 @@ func getFileToTest(implementationName string) (file filesinterfaces.File) {
 			panic(err)
 		}
 	} else if implementationName == "localCommandExecutorFile" {
-		file = files.MustGetLocalCommandExecutorFileByPath(
+		file = mustutils.Must(files.GetLocalCommandExecutorFileByPath(
 			mustutils.Must(tempfilesoo.CreateEmptyTemporaryFileAndGetPath(ctx)),
-		)
+		))
 	} else {
 		logging.LogFatalWithTracef("unknown implementationName='%s'", implementationName)
 	}
@@ -76,19 +76,21 @@ func TestGnuPg_SignAndValidate(t *testing.T) {
 				require.True(t, mustutils.Must(toTest.Exists(ctx)))
 				require.False(t, mustutils.Must(signatureFile.Exists(ctx)))
 
-				MustSignFile(
+				err = SignFile(
+					ctx, 
 					toTest,
 					&GnuPGSignOptions{
 						DetachedSign: true,
 						AsciiArmor:   tt.asciiArmor,
-						Verbose:      verbose,
 					},
 				)
+				require.NoError(t, err)
 
 				require.True(t, mustutils.Must(toTest.Exists(ctx)))
 				require.True(t, mustutils.Must(signatureFile.Exists(ctx)))
 
-				MustCheckSignatureValid(signatureFile, verbose)
+				err = CheckSignatureValid(ctx, signatureFile)
+				require.NoError(t, err)
 			},
 		)
 	}


### PR DESCRIPTION
Use ctx instead of verbose in fileinterface functions IsLocalFile, CheckIsLocalFile and Chown